### PR TITLE
Custom verify url

### DIFF
--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -14,6 +14,7 @@ namespace FoF\ReCaptcha\Listeners;
 use Flarum\Foundation\AbstractValidator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Validation\Validator;
+use ReCaptcha\RequestMethod\Post;
 use ReCaptcha\ReCaptcha;
 
 class AddValidatorRule
@@ -38,7 +39,7 @@ class AddValidatorRule
         $validator->addExtension(
             'recaptcha',
             function ($attribute, $value, $parameters) use ($secret) {
-                return !empty($value) && (new ReCaptcha($secret))->verify($value)->isSuccess();
+                return !empty($value) && (new ReCaptcha($secret, new Post('https://www.recaptcha.net/recaptcha/api/siteverify')))->verify($value)->isSuccess();
             }
         );
     }


### PR DESCRIPTION
This is a workaround to fix in some countries where google.com is not accessible such as China.

For more information: https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
