### PR TITLE
Error handling improvements & test captcha in admin

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -28,7 +28,7 @@ return [
 
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js')
-        ->css(__DIR__ . '/resources/less/admin.less'),
+        ->css(__DIR__.'/resources/less/admin.less'),
 
     new Extend\Locales(__DIR__.'/resources/locale'),
 

--- a/extend.php
+++ b/extend.php
@@ -24,11 +24,11 @@ use FoF\ReCaptcha\Validators\RecaptchaValidator;
 return [
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
-        ->css(__DIR__.'/resources/less/forum.less')
-        ->content(Content\ExtensionSettings::class),
+        ->css(__DIR__.'/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__.'/js/dist/admin.js'),
+        ->js(__DIR__.'/js/dist/admin.js')
+        ->css(__DIR__ . '/resources/less/admin.less'),
 
     new Extend\Locales(__DIR__.'/resources/locale'),
 
@@ -36,10 +36,15 @@ return [
         ->default('fof-recaptcha.signup', true)
         ->default('fof-recaptcha.signin', true)
         ->default('fof-recaptcha.forgot', true)
-        ->serializeToForum('darkMode', 'theme_dark_mode', 'boolVal')
+        ->serializeToForum('theme_dark_mode', 'theme_dark_mode', 'boolVal')
+        ->serializeToForum('fof-recaptcha.credentials.site', 'fof-recaptcha.credentials.site')
+        ->serializeToForum('fof-recaptcha.type', 'fof-recaptcha.type')
         ->serializeToForum('fof-recaptcha.signup', 'fof-recaptcha.signup', 'boolVal')
         ->serializeToForum('fof-recaptcha.signin', 'fof-recaptcha.signin', 'boolVal')
         ->serializeToForum('fof-recaptcha.forgot', 'fof-recaptcha.forgot', 'boolVal'),
+
+    (new Extend\Routes('api'))
+        ->post('/fof/recaptcha/test', 'fof-recaptcha.test', Api\Controller\TestReCaptchaController::class),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->attribute('postWithoutCaptcha', function (ForumSerializer $serializer) {

--- a/js/src/admin/components/RecaptchaPage.tsx
+++ b/js/src/admin/components/RecaptchaPage.tsx
@@ -1,0 +1,24 @@
+import ExtensionPage, { ExtensionPageAttrs } from 'flarum/admin/components/ExtensionPage';
+import Mithril from 'mithril';
+import ItemList from 'flarum/common/utils/ItemList';
+import RecaptchaTest from './RecaptchaTest';
+
+export default class RecaptchaPage extends ExtensionPage {
+  sections(vnode: Mithril.VnodeDOM<ExtensionPageAttrs, this>): ItemList<unknown> {
+    const items = super.sections(vnode);
+
+    const settings = { ...this.settings };
+
+    for (const key in settings) {
+      if (settings[key] instanceof Function) {
+        settings[key] = settings[key].call(this);
+      }
+    }
+
+    items.add('recaptcha', <RecaptchaTest settings={settings} />);
+
+    items.setPriority('permissions', -1);
+
+    return items;
+  }
+}

--- a/js/src/admin/components/RecaptchaTest.tsx
+++ b/js/src/admin/components/RecaptchaTest.tsx
@@ -1,0 +1,133 @@
+import type Mithril from 'mithril';
+import app from 'flarum/admin/app';
+
+import Component, { ComponentAttrs } from 'flarum/common/Component';
+import RecaptchaState from '../../common/states/RecaptchaState';
+import Recaptcha from '../../common/components/Recaptcha';
+import Button from 'flarum/common/components/Button';
+import Alert from 'flarum/common/components/Alert';
+import classList from 'flarum/common/utils/classList';
+
+export default class RecaptchaTest extends Component<any, RecaptchaState | null> {
+  loading = false;
+  alertAttrs: any;
+
+  view(vnode: Mithril.Vnode<ComponentAttrs, this>): Mithril.Children {
+    return (
+      <div className="RecaptchaPage-recaptcha">
+        <div class="ExtensionPage-permissions-header">
+          <div class="container">
+            <h2 className="ExtensionTitle">{app.translator.trans('fof-recaptcha.admin.test.title')}</h2>
+          </div>
+        </div>
+        <div class="container">
+          <form onsubmit={this.onsubmit.bind(this)} className={classList('FoFReCaptchaTestForm', this.state?.isInvisible() && 'isInvisible')}>
+            <div class="Form-group Form-group--recaptcha">
+              <p class="helpText">{app.translator.trans('fof-recaptcha.admin.test.help_text')}</p>
+
+              {this.alertAttrs && <Alert {...this.alertAttrs} dismissible={false} />}
+
+              {this.state && <Recaptcha state={this.state} />}
+            </div>
+
+            <div class="Form-group">
+              <div class="ButtonGroup">
+                <Button className="Button Button--primary" type="submit" loading={this.loading}>
+                  {app.translator.trans(`fof-recaptcha.admin.test.${this.state ? 'submit' : 'load_test'}_button`)}
+                </Button>
+
+                {this.state && (
+                  <Button className="Button" onclick={this.initialize.bind(this)}>
+                    {app.translator.trans('fof-recaptcha.admin.test.reload_button')}
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            <div class="Form-group"></div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+
+  destroy() {
+    this.state = null;
+    this.alertAttrs = null;
+    this.loading = false;
+
+    m.redraw.sync();
+  }
+
+  initialize() {
+    this.destroy();
+
+    const data = this.attrs.settings || app.data.settings;
+
+    this.state = new RecaptchaState(
+      data,
+      () => {
+        if (this.state!.isInvisible()) {
+          // Create "fake" event so this works when other extensions extend onsubmit as well
+          const event = new Event('submit');
+          event.isRecaptchaSecondStep = true;
+          this.onsubmit(event);
+        }
+      },
+      this.onerror
+    );
+  }
+
+  async onsubmit(e: Event) {
+    e.preventDefault();
+
+    if (!this.state) {
+      return this.initialize();
+    }
+
+    this.alertAttrs = null;
+    this.loading = true;
+    m.redraw();
+
+    if (this.state.isInvisible() && !e.isRecaptchaSecondStep) {
+      // When recaptcha is invisible, onsubmit will be called two times
+      // First time with normal event, we will call recaptcha.execute
+      // Second time is called from recaptcha callback with a special isRecaptcha attribute
+      e.preventDefault();
+      this.state.execute();
+      return;
+    }
+
+    const body = {
+      'g-recaptcha-response': this.state.getResponse(),
+    };
+
+    try {
+      await app.request({
+        method: 'POST',
+        url: `${app.forum.attribute('apiUrl')}/fof/recaptcha/test`,
+        body,
+        errorHandler: () => {},
+      });
+    } catch (e) {
+      return this.onerror(e);
+    }
+
+    this.loading = false;
+    this.alertAttrs = {
+      type: 'success',
+      content: app.translator.trans('fof-recaptcha.admin.test.success_message'),
+    };
+    this.state.reset();
+    m.redraw();
+  }
+
+  onerror(error) {
+    const alert = error.alert || error;
+    1;
+    this.loading = false;
+    this.alertAttrs = alert;
+    this.state.reset();
+    m.redraw();
+  }
+}

--- a/js/src/admin/components/RecaptchaTest.tsx
+++ b/js/src/admin/components/RecaptchaTest.tsx
@@ -124,10 +124,10 @@ export default class RecaptchaTest extends Component<any, RecaptchaState | null>
 
   onerror(error) {
     const alert = error.alert || error;
-    1;
+
     this.loading = false;
     this.alertAttrs = alert;
-    this.state.reset();
+    this.state?.reset();
     m.redraw();
   }
 }

--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -6,6 +6,7 @@ app.initializers.add('fof/recaptcha', () => {
     .registerSetting({
       setting: 'fof-recaptcha.type',
       label: app.translator.trans('fof-recaptcha.admin.settings.type_label'),
+      help: app.translator.trans('fof-recaptcha.admin.settings.type_help'),
       options: {
         checkbox: 'Checkbox',
         invisible: 'Invisible',

--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -1,8 +1,10 @@
 import app from 'flarum/admin/app';
+import RecaptchaPage from './components/RecaptchaPage';
 
 app.initializers.add('fof/recaptcha', () => {
   app.extensionData
     .for('fof-recaptcha')
+    .registerPage(RecaptchaPage)
     .registerSetting({
       setting: 'fof-recaptcha.type',
       label: app.translator.trans('fof-recaptcha.admin.settings.type_label'),

--- a/js/src/common/components/Recaptcha.js
+++ b/js/src/common/components/Recaptcha.js
@@ -1,11 +1,11 @@
-import app from 'flarum/forum/app';
+import app from 'flarum/common/app';
 import Component from 'flarum/common/Component';
 import load from 'external-load';
 
 const addResources = async () => {
   if (app.recaptchaLoaded) return;
 
-  await load.js(`https://www.recaptcha.net/recaptcha/api.js?hl=${app.translator.locale}&render=explicit`);
+  await load.js(`https://www.recaptcha.net/recaptcha/api.js?hl=${app.translator.getLocale()}&render=explicit`);
 
   app.recaptchaLoaded = true;
 };
@@ -36,7 +36,7 @@ export default class Recaptcha extends Component {
     });
 
     // It's possible to TAB into the reCAPTCHA iframe, and it's very confusing when using the invisible mode
-    if (app.data['fof-recaptcha.type'] === 'invisible') {
+    if (this.attrs.state.type === 'invisible') {
       const iframe = vnode.dom.querySelector('iframe');
 
       if (iframe) {

--- a/js/src/common/states/RecaptchaState.js
+++ b/js/src/common/states/RecaptchaState.js
@@ -1,7 +1,8 @@
-import app from 'flarum/forum/app';
+import app from 'flarum/common/app';
 
 export default class RecaptchaState {
-  constructor(callback, errorCallback = null) {
+  constructor(settings, callback, errorCallback = null) {
+    this.settings = settings;
     this.callback = callback;
     this.errorCallback =
       errorCallback ||
@@ -10,14 +11,16 @@ export default class RecaptchaState {
         app.alerts.show(alertAttrs);
       });
     this.widgetId = null;
+
+    this.type = this.settings['fof-recaptcha.type'];
   }
 
   render(element) {
     this.widgetId = grecaptcha.render(element, {
-      sitekey: app.data['fof-recaptcha.credentials.site'],
-      theme: app.forum.attribute('darkMode') ? 'dark' : 'light',
-      type: app.data['fof-recaptcha.type'],
-      size: app.data['fof-recaptcha.type'] === 'invisible' ? 'invisible' : 'normal',
+      sitekey: this.settings['fof-recaptcha.credentials.site'],
+      theme: !!Number(this.settings['theme_dark_mode']) ? 'dark' : 'light',
+      type: this.type,
+      size: this.settings['fof-recaptcha.type'] === 'invisible' ? 'invisible' : 'normal',
       callback: this.callback,
       'error-callback': () => {
         // Similarly to error.alert, we create an alert payload that can then be shown in-context depending where the code is called from
@@ -40,5 +43,9 @@ export default class RecaptchaState {
 
   reset() {
     return grecaptcha.reset(this.widgetId);
+  }
+
+  isInvisible() {
+    return this.type === 'invisible';
   }
 }

--- a/js/src/forum/extendComposer.js
+++ b/js/src/forum/extendComposer.js
@@ -1,18 +1,16 @@
 import app from 'flarum/forum/app';
 import { extend, override } from 'flarum/common/extend';
-import RecaptchaState from './states/RecaptchaState';
-import Recaptcha from './components/Recaptcha';
+import RecaptchaState from '../common/states/RecaptchaState';
+import Recaptcha from '../common/components/Recaptcha';
 
 export default function (Composer) {
-  const isInvisible = app.data['fof-recaptcha.type'] === 'invisible';
-
   extend(Composer.prototype, 'oninit', function () {
     if (app.forum.attribute('postWithoutCaptcha')) {
       return;
     }
 
-    this.recaptcha = new RecaptchaState(() => {
-      if (isInvisible) {
+    this.recaptcha = new RecaptchaState(app.forum.data.attributes, () => {
+      if (this.recaptcha.isInvisible()) {
         // onsubmit is usually called without any argument.
         // We use the first argument to indicate the second call after invisible recaptcha
         this.onsubmit('recaptchaSecondStep');
@@ -52,7 +50,7 @@ export default function (Composer) {
   });
 
   override(Composer.prototype, 'onsubmit', function (original, argument1) {
-    if (!app.forum.attribute('postWithoutCaptcha') && isInvisible && argument1 !== 'recaptchaSecondStep') {
+    if (!app.forum.attribute('postWithoutCaptcha') && this.recaptcha.isInvisible() && argument1 !== 'recaptchaSecondStep') {
       this.loading = true;
       this.recaptcha.execute();
       return;

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -1,0 +1,29 @@
+.fof-recaptcha-Page {
+  .FoFReCaptchaTestForm {
+    min-width: 300px;
+    max-width: 500px;
+    width: fit-content;
+    overflow: hidden;
+
+    .helpText--danger {
+      color: var(--control-danger-color);
+      font-weight: bold;
+    }
+
+    .Form-group--recaptcha .Form-group {
+      margin-top: 20px;
+    }
+
+    &.isInvisible {
+      .Form-group--recaptcha .Form-group {
+        height: 60px;
+        position: relative;
+
+        .grecaptcha-badge {
+          position: absolute !important;
+          bottom: 0 !important;
+        }
+      }
+    }
+  }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -17,3 +17,4 @@ fof-recaptcha:
 
 validation:
   recaptcha: reCAPTCHA validation failed.
+  recaptcha-unknown: An unknown error occurred while validating reCAPTCHA ({errors}).

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -5,6 +5,7 @@ fof-recaptcha:
       secret_key_label: Secret Key
       site_key_label: Site Key
       type_label: reCAPTCHA Type
+      type_help: This extension only supports reCAPTCHA v2. The selected type must match the type of your reCAPTCHA credentials.
       signup: => core.forum.sign_up.title
       signin: => core.forum.log_in.title
       forgot: => core.forum.forgot_password.title

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -6,9 +6,21 @@ fof-recaptcha:
       site_key_label: Site Key
       type_label: reCAPTCHA Type
       type_help: This extension only supports reCAPTCHA v2. The selected type must match the type of your reCAPTCHA credentials.
+
       signup: => core.forum.sign_up.title
       signin: => core.forum.log_in.title
       forgot: => core.forum.forgot_password.title
+
+    test:
+      title: Test reCAPTCHA
+      help_text: |
+        This test will use the current values entered above. Make sure to reload the test after modifying settings, and don't forget to save once the test passes!
+        Below may not reflect the saved settings.
+      success_message: Success! reCAPTCHA is configured correctly.
+      load_test_button: Load
+      submit_button: Submit
+      reload_button: Reload
+
     permissions:
       post_without_captcha: Create posts and discussions without captcha
   forum:

--- a/src/Api/Controller/TestReCaptchaController.php
+++ b/src/Api/Controller/TestReCaptchaController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/recaptcha.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\ReCaptcha\Api\Controller;
 
 use Flarum\Http\RequestUtil;

--- a/src/Api/Controller/TestReCaptchaController.php
+++ b/src/Api/Controller/TestReCaptchaController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FoF\ReCaptcha\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use FoF\ReCaptcha\Validators\RecaptchaValidator;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class TestReCaptchaController implements RequestHandlerInterface
+{
+    /**
+     * @var RecaptchaValidator
+     */
+    protected $validator;
+
+    public function __construct(RecaptchaValidator $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $actor = RequestUtil::getActor($request);
+
+        $actor->assertAdmin();
+
+        $data = $request->getParsedBody();
+
+        $this->validator->assertValid([
+            'recaptcha' => Arr::get($data, 'g-recaptcha-response'),
+        ]);
+
+        return new EmptyResponse();
+    }
+}

--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -18,8 +18,6 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\ReCaptcha\ReCaptcha\GuzzleRequestMethod;
 use Illuminate\Validation\Validator;
 use ReCaptcha\ReCaptcha;
-use ReCaptcha\RequestMethod\CurlPost;
-use ReCaptcha\RequestMethod\Post;
 
 class AddValidatorRule
 {
@@ -43,13 +41,16 @@ class AddValidatorRule
         $validator->addExtension(
             'recaptcha',
             function ($attribute, $value, $parameters) use ($validator, $secret) {
-                if (empty($value)) return false;
+                if (empty($value)) {
+                    return false;
+                }
 
                 $verification = (new ReCaptcha($secret, new GuzzleRequestMethod('https://www.recaptcha.net/recaptcha/api/siteverify')))->verify($value);
 
                 if (!empty($verification->getErrorCodes())) {
-                    $validator->setCustomMessages([
-                        'recaptcha' => resolve('translator')->trans('validation.recaptcha-unknown', ['errors' => implode(', ', $verification->getErrorCodes())])]
+                    $validator->setCustomMessages(
+                        [
+                            'recaptcha' => resolve('translator')->trans('validation.recaptcha-unknown', ['errors' => implode(', ', $verification->getErrorCodes())])]
                     );
                 }
 

--- a/src/Listeners/ReplyPostValidate.php
+++ b/src/Listeners/ReplyPostValidate.php
@@ -36,7 +36,7 @@ class ReplyPostValidate
             // If it's a new discussion, the reCAPTCHA is already validated in discussion saving event
             // When this code runs, the discussion already exists, and the number has not been assigned to the post yet
             // So we look in the discussion number index, just like the reply permission check does in PostReplyHandler
-            if ($event->post->discussion->post_number_index === 0) {
+            if ($event->post->number == 1 || $event->post->discussion->first_post_id === null) {
                 return;
             }
 

--- a/src/ReCaptcha/GuzzleRequestMethod.php
+++ b/src/ReCaptcha/GuzzleRequestMethod.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/recaptcha.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\ReCaptcha\ReCaptcha;
 
 use GuzzleHttp\Client;

--- a/src/ReCaptcha/GuzzleRequestMethod.php
+++ b/src/ReCaptcha/GuzzleRequestMethod.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace FoF\ReCaptcha\ReCaptcha;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use ReCaptcha\ReCaptcha;
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestParameters;
+
+class GuzzleRequestMethod implements RequestMethod
+{
+    /**
+     * @var string
+     */
+    private $siteVerifyUrl;
+
+    /**
+     * @param $siteVerifyUrl string|null
+     */
+    public function __construct(string $siteVerifyUrl = null)
+    {
+        $this->siteVerifyUrl = $siteVerifyUrl ?? ReCaptcha::SITE_VERIFY_URL;
+    }
+
+    public function submit(RequestParameters $params)
+    {
+        $client = new Client();
+
+        try {
+            $response = $client->post($this->siteVerifyUrl, [
+                'form_params' => $params->toArray(),
+            ]);
+
+            return $response->getBody()->getContents();
+        } catch (\Throwable $e) {
+            $error = ReCaptcha::E_UNKNOWN_ERROR;
+
+            if ($e instanceof BadResponseException) {
+                $error = ReCaptcha::E_BAD_RESPONSE;
+            } elseif ($e instanceof ConnectException) {
+                $error = ReCaptcha::E_CONNECTION_FAILED;
+            }
+
+            resolve('log')->error('[fof/recaptcha] An error occurred while attempting to use the ReCAPTCHA service.');
+            resolve('log')->error($e);
+
+            return sprintf('{"success": false, "error-codes": ["%s"]}', $error);
+        }
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #41**
**Fixes #30**
**Fixes #29**

**Changes proposed in this pull request:**
- Use Guzzle for reCAPTCHA validation
- Pass errors during reCAPTCHA request to user (these errors don't reveal anything harmful, just codes for problems during request) so it doesn't just say validation failed with no other feedback
- Add some helper text to explain a bit more about the captcha type
- Add reCAPTCHA test section that uses current values in input fields
- Fix reply post validation not properly checking for whether the post is the first in a discussion

**Screenshot**
![image](https://github.com/FriendsOfFlarum/recaptcha/assets/6401250/633da9e5-454c-4801-a27c-0995c727ef8a)

![image](https://github.com/FriendsOfFlarum/recaptcha/assets/6401250/c7a1d8d8-ff8e-4f69-bd06-7a0cbdcd2b50)
![image](https://github.com/FriendsOfFlarum/recaptcha/assets/6401250/ca5f5e4d-c817-4fa0-a0ca-47ed8dd94897)
![image](https://github.com/FriendsOfFlarum/recaptcha/assets/6401250/c90a154b-1ed0-4656-8eb4-31f1c49a9610)
![image](https://github.com/FriendsOfFlarum/recaptcha/assets/6401250/ec321dc7-ec0b-4087-856a-c4388a5dcdef)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
