### PR TITLE
[1.x] fix: prevent google/recaptcha from updating to v1.5 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "flarum/core": "^1.6.0",
-        "google/recaptcha": "^1.2"
+        "google/recaptcha": ">=1.2 <1.5"
     },
     "authors": [
         {


### PR DESCRIPTION
v1.3 is the latest for PHP 8.3, but PHP 8.4 supports the latter, and v1.5 has breaking changes that give a **Fatal notice** error.

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
`google/recaptcha` v1.5 introduces breaking changes. Hard to catch since v1.4 and later require PHP 8.4+.

```php
Fatal error: Declaration of FoF\ReCaptcha\ReCaptcha\GuzzleRequestMethod::submit(ReCaptcha\RequestParameters $params) must be compatible with ReCaptcha\RequestMethod::submit(ReCaptcha\RequestParameters $params): string in <FLARUM>\fof-recaptcha\src\ReCaptcha\GuzzleRequestMethod.php on line 36
```

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
