### PR TITLE
[2.x] Frontend: update error handling, styling, and support newer google/recaptcha version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^2.0.0",
+        "flarum/core": "^2.0.0-rc.3",
         "google/recaptcha": "^1.3"
     },
     "authors": [

--- a/js/src/forum/extendAuthModals.tsx
+++ b/js/src/forum/extendAuthModals.tsx
@@ -65,23 +65,6 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
     fields.add('recaptcha', <Recaptcha state={self.recaptcha} />, -5);
   });
 
-  extend(modulePath, 'onerror', function (_: unknown, ...args: unknown[]) {
-    if (!shouldApply()) return;
-
-    const self = this as unknown as ModalWithRecaptcha;
-    const error = args[0] as { alert?: { content?: Mithril.Children } };
-    const hadToken = !!self.recaptchaToken;
-    self.recaptchaToken = null;
-    self.recaptcha.reset();
-
-    // The /login route returns an HTML error page rather than structured JSON for validation failures,
-    // so the alert content is empty by the time it reaches us. We infer the most likely cause and
-    // surface a clearer message than the generic "unknown error" fallback.
-    if (type === 'signin' && error.alert && (!error.alert.content || !(error.alert.content as unknown[]).length)) {
-      error.alert.content = app.translator.trans(hadToken ? 'fof-recaptcha.lib.rejected' : 'fof-recaptcha.lib.not_completed');
-    }
-  });
-
   override(modulePath, 'onsubmit', function (original: unknown, ...args: unknown[]) {
     const self = this as unknown as ModalWithRecaptcha;
     const e = args[0] as Event;
@@ -89,19 +72,6 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
 
     if (!shouldApply()) {
       return proceed();
-    }
-
-    // v2 checkbox: verify the user ticked the box before we submit. Skipping this lets the request
-    // fall into the server-side /login HTML error path, which is much harder to report to the user.
-    if (!self.recaptcha.requiresAsyncToken() && !self.recaptcha.getResponse()) {
-      e.preventDefault();
-      self.loaded();
-      self.alertAttrs = {
-        type: 'error',
-        content: app.translator.trans('fof-recaptcha.lib.not_completed'),
-      };
-      m.redraw();
-      return;
     }
 
     if (!self.recaptcha.requiresAsyncToken() || self.recaptchaToken !== null) {

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -1,3 +1,5 @@
+@import './common.less';
+
 .fof-recaptcha-Page {
   .FoFReCaptchaTestForm {
     min-width: 300px;

--- a/resources/less/common.less
+++ b/resources/less/common.less
@@ -1,0 +1,33 @@
+#fof-recaptcha {
+  align-items: center;
+
+  .g-recaptcha {
+    // Background to show space isn't empty
+    background-color: var(--body-bg);
+    border-radius: 3px;
+
+    // We give a border to let the user know something is here before reCAPTCHA loads.
+    // Remove it after since it seems to clash with iframe.
+    &:empty {
+      border: 0.5px dotted var(--control-color);
+    }
+
+    // reCAPTCHA size is 304x78 but contains white bars. See https://stackoverflow.com/a/32547295 for this fix.
+    // There were other fixes without iframe margin but they didn't seem to work as well.
+    overflow: hidden;
+    width:298px;
+    height:74px;
+
+    iframe {
+      margin: -1px 0 0 -2px;
+    }
+
+    > div {
+      overflow: hidden;
+    }
+
+    .grecaptcha-badge {
+      position: absolute !important;
+    }
+  }
+}

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,14 +1,4 @@
-.SignUpModal, .LogInModal, .ForgotPasswordModal, .ChangePasswordModal {
-  .g-recaptcha {
-    > div {
-      width: auto !important;
-    }
-
-    .grecaptcha-badge {
-      position: absolute !important;
-    }
-  }
-}
+@import './common.less';
 
 .ComposerBody-header .item-recaptcha {
   display: block; // So it's always on its own line
@@ -40,6 +30,20 @@
       .g-recaptcha {
         transform-origin: 0 0;
       }
+    }
+  }
+
+  // Avoid reCAPTCHA challenge going off-screen on mobile.
+  // See https://github.com/google/recaptcha/issues/334#issuecomment-1864799155
+  .g-recaptcha-bubble-arrow {
+    display: none;
+
+    + div {
+      position: fixed !important;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      -webkit-transform: translate(-50%, -50%);
     }
   }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -43,3 +43,6 @@ fof-recaptcha:
 validation:
   recaptcha: reCAPTCHA validation failed.
   recaptcha-unknown: An unknown error occurred while validating reCAPTCHA ({errors}).
+
+  attributes:
+    g-recaptcha-response: reCAPTCHA

--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -14,6 +14,7 @@ namespace FoF\ReCaptcha\Listeners;
 use Flarum\Api\ForgotPasswordValidator;
 use Flarum\Forum\LogInValidator;
 use Flarum\Foundation\AbstractValidator;
+use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\ReCaptcha\ReCaptcha\GuzzleRequestMethod;
 use FoF\ReCaptcha\Utils;
@@ -70,15 +71,17 @@ class AddValidatorRule
             }
         );
 
-        if ($flarumValidator instanceof LogInValidator && $this->settings->get('fof-recaptcha.signin')) {
+        $addRule = (
+            ($flarumValidator instanceof LogInValidator && $this->settings->get('fof-recaptcha.signin')) ||
+            ($flarumValidator instanceof ForgotPasswordValidator && $this->settings->get('fof-recaptcha.forgot'))
+        );
+
+        if ($addRule) {
             $validator->addRules([
                 'g-recaptcha-response' => ['required', 'recaptcha'],
             ]);
-        }
-
-        if ($flarumValidator instanceof ForgotPasswordValidator && $this->settings->get('fof-recaptcha.forgot')) {
-            $validator->addRules([
-                'g-recaptcha-response' => ['required', 'recaptcha'],
+            $validator->setCustomMessages([
+                'g-recaptcha-response.required' => resolve(TranslatorInterface::class)->trans('fof-recaptcha.lib.not_completed'),
             ]);
         }
     }

--- a/src/ReCaptcha/GuzzleRequestMethod.php
+++ b/src/ReCaptcha/GuzzleRequestMethod.php
@@ -30,7 +30,7 @@ class GuzzleRequestMethod implements RequestMethod
         $this->siteVerifyUrl = $siteVerifyUrl ?? ReCaptcha::SITE_VERIFY_URL;
     }
 
-    public function submit(RequestParameters $params)
+    public function submit(RequestParameters $params): string
     {
         $client = new Client();
 

--- a/src/Validators/RecaptchaValidator.php
+++ b/src/Validators/RecaptchaValidator.php
@@ -21,4 +21,8 @@ class RecaptchaValidator extends AbstractValidator
             'recaptcha',
         ],
     ];
+
+    protected array $messages = [
+        'g-recaptcha-response.required' => 'fof-recaptcha.forum.validation.required',
+    ];
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- fix: support google/recaptcha v1.5 --- added a return type to a method, seems backwards compatible
- improve error handling
  - add custom validation message for required captcha error (instead of "`g-recaptcha` is required")
  - chore: remove custom error handling and early captcha termination
- improve recaptcha styling by hiding extra white background
- fix mobile recaptcha challenge going off screen

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**

https://github.com/user-attachments/assets/f86433ae-10ec-4b39-9ecd-e272b44489f2

<img width="549" height="637" alt="image" src="https://github.com/user-attachments/assets/baf453ee-7e4c-4afc-8b93-ae21a15ef081" />
<img width="532" height="809" alt="image" src="https://github.com/user-attachments/assets/34801f27-dd61-4bed-b2b7-288d4cbdb7be" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
