### PR TITLE
[2.x] Improve behavior with maintenance mode and 2FA extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
                 "color": "#fff"
             },
             "optional-dependencies": [
-                "fof/oauth"
+                "fof/oauth",
+                "ianm/twofactor"
             ]
         },
         "flagrow": {

--- a/js/src/admin/components/RecaptchaPage.tsx
+++ b/js/src/admin/components/RecaptchaPage.tsx
@@ -1,3 +1,4 @@
+import app from 'flarum/admin/app';
 import ExtensionPage, { ExtensionPageAttrs } from 'flarum/admin/components/ExtensionPage';
 import Mithril from 'mithril';
 import ItemList from 'flarum/common/utils/ItemList';
@@ -13,6 +14,14 @@ export default class RecaptchaPage extends ExtensionPage {
       if (settings[key] instanceof Function) {
         settings[key] = settings[key].call(this);
       }
+    }
+
+    if (app.data.maintenanceMode) {
+      items.add(
+        'maintenance',
+        <div className="Alert Alert--danger">{app.translator.trans('fof-recaptcha.admin.maintenance_mode_warning')}</div>,
+        100
+      );
     }
 
     items.add('recaptcha', <RecaptchaTest settings={settings} />);

--- a/js/src/forum/extendAuthModals.tsx
+++ b/js/src/forum/extendAuthModals.tsx
@@ -9,6 +9,7 @@ import Recaptcha from '../common/components/Recaptcha';
 interface ModalWithRecaptcha {
   recaptcha: RecaptchaState;
   recaptchaToken: string | null;
+  recaptchaDisable: boolean;
   alertAttrs: AlertAttrs | null;
   loading: boolean;
   loaded(): void;
@@ -45,12 +46,14 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
       }
     );
     self.recaptchaToken = null;
+    self.recaptchaDisable = false;
   });
 
   extend(modulePath, dataMethod, function (data: Record<string, unknown>) {
-    if (!shouldApply()) return;
-
     const self = this as unknown as ModalWithRecaptcha;
+
+    if (!shouldApply() || self.recaptchaDisable) return;
+
     data['g-recaptcha-response'] = self.recaptcha.requiresAsyncToken() ? (self.recaptchaToken ?? '') : self.recaptcha.getResponse();
     data['g-recaptcha-action'] = self.recaptcha.action;
   });
@@ -60,9 +63,14 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
 
     const self = this as unknown as ModalWithRecaptcha;
 
-    // The Recaptcha component is rendered for every type, including v3 (where it's an invisible
-    // marker div). Mounting it in all modes is how the grecaptcha script gets loaded.
-    fields.add('recaptcha', <Recaptcha state={self.recaptcha} />, -5);
+    // If 2FA field is present, user has already passed reCAPTCHA.
+    self.recaptchaDisable = fields.has('twoFactor');
+
+    if (!self.recaptchaDisable) {
+      // The Recaptcha component is rendered for every type, including v3 (where it's an invisible
+      // marker div). Mounting it in all modes is how the grecaptcha script gets loaded.
+      fields.add('recaptcha', <Recaptcha state={self.recaptcha} />, -5);
+    }
   });
 
   override(modulePath, 'onsubmit', function (original: unknown, ...args: unknown[]) {
@@ -70,7 +78,7 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
     const e = args[0] as Event;
     const proceed = () => (original as (e: Event) => unknown)(e);
 
-    if (!shouldApply()) {
+    if (!shouldApply() || self.recaptchaDisable) {
       return proceed();
     }
 
@@ -83,7 +91,7 @@ function applyAuthModalExtension({ modulePath, type, dataMethod }: AuthModalConf
     self.loading = true;
     m.redraw();
 
-    self.recaptcha
+    return self.recaptcha
       .acquireToken()
       .then((token) => {
         self.recaptchaToken = token;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,5 +1,7 @@
 fof-recaptcha:
   admin:
+    maintenance_mode_warning: reCAPTCHA is disabled in the login page when the forum is in maintenance mode.
+
     settings:
       help_text: Obtain your Google reCAPTCHA credentials <a>here</a>.
       secret_key_label: Secret Key

--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -14,6 +14,7 @@ namespace FoF\ReCaptcha\Listeners;
 use Flarum\Api\ForgotPasswordValidator;
 use Flarum\Forum\LogInValidator;
 use Flarum\Foundation\AbstractValidator;
+use Flarum\Foundation\MaintenanceMode;
 use Flarum\Locale\TranslatorInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\ReCaptcha\ReCaptcha\GuzzleRequestMethod;
@@ -24,7 +25,10 @@ use ReCaptcha\ReCaptcha;
 
 class AddValidatorRule
 {
-    public function __construct(protected SettingsRepositoryInterface $settings)
+    public function __construct(
+        protected SettingsRepositoryInterface $settings,
+        protected MaintenanceMode $maintenanceMode
+    )
     {
     }
 
@@ -76,7 +80,7 @@ class AddValidatorRule
             ($flarumValidator instanceof ForgotPasswordValidator && $this->settings->get('fof-recaptcha.forgot'))
         );
 
-        if ($addRule) {
+        if ($addRule && !$this->maintenanceMode->inMaintenanceMode()) {
             $validator->addRules([
                 'g-recaptcha-response' => ['required', 'recaptcha'],
             ]);

--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -28,8 +28,7 @@ class AddValidatorRule
     public function __construct(
         protected SettingsRepositoryInterface $settings,
         protected MaintenanceMode $maintenanceMode
-    )
-    {
+    ) {
     }
 
     public function __invoke(AbstractValidator $flarumValidator, Validator $validator): void


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #55**
**Refs #52**

**Changes proposed in this pull request:**
- Disable reCAPTCHA during login/password flows in maintenance mode
  - In the future, we could optionally serve a custom view to require reCAPTCHA. That felt unnecessary for right now, and would not avoid incompatibilities with other extensions.
- Remove reCAPTCHA from login after user submits username/password and gets to 2FA form
    - The ianm/twofactor extension works by submitting the username/password (+ recaptcha) form, then replaces fields with 2FA. Currently, reCAPTCHA appears for both forms, but is only checked in the backend during the first, which makes sense. This removes it from the second form as it is not verified.
    - In other words, this simply removes the frontend recaptcha from a form where it is not checked in the backend. The login flow still requires reCAPTCHA before the 2FA code. 

**Reviewers should focus on:**


**Screenshot**
<img width="657" height="530" alt="image" src="https://github.com/user-attachments/assets/5a22fd19-ef22-454a-840e-761807e64971" />
<img width="1019" height="357" alt="image" src="https://github.com/user-attachments/assets/edc27013-bf88-4050-8ff3-89dd30a7012e" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
